### PR TITLE
Fix unordered list bullets on mobile

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -88,6 +88,7 @@ a:hover {
 ul {
   margin-bottom: 1.25em;
   padding-left: 1.625em;
+  list-style-type: circle;
 }
 
 ul.posts {


### PR DESCRIPTION
### Motivation
- Mobile browsers did not display the circular list markers because the stylesheet relied on a custom `::marker` content; enforcing `list-style-type: circle` on `ul` ensures consistent circular bullets across devices.

### Description
- Add `list-style-type: circle;` to the `ul` rule in `static/main.css` to restore circle bullets on mobile.

### Testing
- Attempted to validate with `zola --version` but `zola` is not installed in the environment so a site build/test could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868c01bbd083279fc3b16e7b6d9221)