### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Zola
+        uses: taiki-e/install-action@v2
+        with:
+          tool: zola@0.20.0
+
+      - name: Build site
+        run: zola build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Add an automated GitHub Actions workflow to build and deploy the site to GitHub Pages on pushes to `main` and via manual dispatch; the repository appears to be a Zola site so the workflow uses `zola build`.

### Description
- Add `.github/workflows/deploy-pages.yml` that triggers on `push` to `main` and `workflow_dispatch`, and configures Pages permissions (`contents: read`, `pages: write`, `id-token: write`) with concurrency controls.
- The `build` job checks out the repository with submodules, installs Zola via `taiki-e/install-action@v2`, and runs `zola build` to generate the `public` output.
- The workflow sets up Pages with `actions/configure-pages@v5`, uploads the `public` directory via `actions/upload-pages-artifact@v4`, and deploys using `actions/deploy-pages@v4` to the `github-pages` environment.

### Testing
- Displayed and validated the new workflow file contents and verified the diff to confirm the workflow YAML is present and well-formed; those automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0510d2e7048327bb2c2bd9c920ff25)